### PR TITLE
Complete refactor of errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "regex",
  "serde",
  "shrinkwraprs",
+ "thiserror",
 ]
 
 [[package]]
@@ -219,6 +220,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ byteorder = "1.4.3"
 num = "0.4.0"
 serde = { version = "1.0.125" }
 shrinkwraprs = "0.3.0"
+thiserror = "1.0.24"
 
 [dev-dependencies]
 difference = "2.0.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,121 +1,79 @@
 //! Error objects and codes
 
-use serde::{de, ser};
-use std::error;
 use std::fmt;
 use std::io;
 use std::result;
 
-#[derive(Clone, PartialEq, Debug)]
-pub enum ErrorCode {
-    /// Unsupported opcode
-    Unsupported(char),
-    /// EOF while parsing op argument
-    EofWhileParsing,
-    /// Stack underflowed
-    StackUnderflow,
-    /// Length prefix found negative
-    NegativeLength,
-    /// String decoding as UTF-8 failed
-    StringNotUtf8,
-    /// Wrong stack top type for opcode
-    InvalidStackTop(&'static str, String),
-    /// Value not hashable, but used as dict key or set item
-    ValueNotHashable,
-    /// Recursive structure found, which we don't support
-    Recursive,
-    /// A "module global" reference wasn't resolved by REDUCE
-    UnresolvedGlobal,
-    /// A "module global" isn't supported
-    UnsupportedGlobal(Vec<u8>, Vec<u8>),
-    /// A value was missing from the memo
-    MissingMemo(u32),
-    /// Invalid literal found
-    InvalidLiteral(Vec<u8>),
-    /// Found trailing bytes after STOP opcode
-    TrailingBytes,
-    /// Invalid value in stream
-    InvalidValue(String),
-    /// Structure deserialization error (e.g., unknown variant)
-    Structure(String),
-    /// Tried to deserialize an integer into a type that is too small
-    IntegerSizeMismatch,
-}
+use serde::{de, ser};
+use thiserror::Error;
 
-impl fmt::Display for ErrorCode {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ErrorCode::Unsupported(ch) => write!(fmt, "unsupported opcode {:?}", ch),
-            ErrorCode::EofWhileParsing => write!(fmt, "EOF while parsing"),
-            ErrorCode::StackUnderflow => write!(fmt, "stack underflow"),
-            ErrorCode::NegativeLength => write!(fmt, "negative length prefix"),
-            ErrorCode::StringNotUtf8 => write!(fmt, "string is not UTF-8 encoded"),
-            ErrorCode::InvalidStackTop(what, ref it) => {
-                write!(fmt, "invalid stack top, expected {}, got {}", what, it)
-            }
-            ErrorCode::ValueNotHashable => write!(fmt, "dict key or set item not hashable"),
-            ErrorCode::Recursive => write!(fmt, "recursive structure found"),
-            ErrorCode::UnresolvedGlobal => write!(fmt, "unresolved global reference"),
-            ErrorCode::UnsupportedGlobal(ref m, ref g) => write!(
-                fmt,
-                "unsupported global: {}.{}",
-                String::from_utf8_lossy(m),
-                String::from_utf8_lossy(g)
-            ),
-            ErrorCode::MissingMemo(n) => write!(fmt, "missing memo with id {}", n),
-            ErrorCode::InvalidLiteral(ref l) => {
-                write!(fmt, "literal is invalid: {}", String::from_utf8_lossy(l))
-            }
-            ErrorCode::TrailingBytes => write!(fmt, "trailing bytes found"),
-            ErrorCode::InvalidValue(ref s) => write!(fmt, "invalid value: {}", s),
-            ErrorCode::Structure(ref s) => fmt.write_str(s),
-            ErrorCode::IntegerSizeMismatch => write!(fmt, "Integer Size Mismatch"),
-        }
-    }
-}
+/// A result whose error type is `Error`.
+pub type Result<A> = result::Result<A, Error>;
 
-/// This type represents all possible errors that can occur when serializing or
-/// deserializing a value.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum Error {
-    /// Some IO error occurred when serializing or deserializing a value.
-    Io(io::Error),
-    /// The deserializer had some error while interpreting.
-    Eval(ErrorCode, usize),
-    /// Syntax error while transforming into Rust values.
-    Syntax(ErrorCode),
+    /// Error in underlying IO
+    #[error("io error")]
+    Io(#[from] io::Error),
+
+    /// The end of stream was reached unexpectedly.
+    #[error("end of stream")]
+    EndOfStream,
+
+    /// Size not given when serializing a sequence
+    #[error("Attempting to serialize a sequence but size not provided")]
+    SeqSizeNotProvided,
+
+    /// Invalid byte
+    #[error(
+        "Invalid byte for deserializing a {dtype}. Expected one of: {allowed:?}, found: {byte}"
+    )]
+    InvalidByte {
+        byte: u8,
+        dtype: String,
+        allowed: Vec<u8>,
+    },
+
+    /// Invalid utf-8 char
+    #[error("Invalid byte sequence when attempting to deserialize utf-8 char: {bytes:?}")]
+    InvalidUtf8 { bytes: Vec<u8> },
+
+    /// Invalid integer prefix byte
+    #[error("Invalid byte when deserializing an integer. First byte must be a size flag or a value < 0x80")]
+    InvalidIntegerByte { byte: u8 },
+
+    /// Destination integer type too small
+    #[error("Attempted to deserialize an integer into a desgination type that is too small")]
+    DestinationIntegerOverflow,
+
+    /// Error occurred at a given position (recursive variant) [not currently used]
+    #[error("Error: {error}, at position: {pos}")]
+    ErrorAt {
+        #[source]
+        error: Box<Error>,
+        pos: usize,
+    },
+
+    /// Some user-defined error occurred.
+    #[error("{message}")]
+    Custom {
+        /// The user-defined error message.
+        message: String,
+    },
 }
-
-impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Error {
-        Error::Io(error)
-    }
-}
-
-pub type Result<T> = result::Result<T, Error>;
-
-impl fmt::Display for Error {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::Io(ref error) => error.fmt(fmt),
-            Error::Eval(ref code, offset) => {
-                write!(fmt, "eval error at offset {}: {}", offset, code)
-            }
-            Error::Syntax(ref code) => write!(fmt, "decoding error: {}", code),
-        }
-    }
-}
-
-impl error::Error for Error {}
 
 impl de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {
-        Error::Syntax(ErrorCode::Structure(msg.to_string()))
+        Error::Custom {
+            message: msg.to_string(),
+        }
     }
 }
 
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Error {
-        Error::Syntax(ErrorCode::Structure(msg.to_string()))
+        Error::Custom {
+            message: msg.to_string(),
+        }
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use crate::WriteBinProtExt;
-use serde::ser::{self, Error as SerError};
+use serde::ser;
 use serde::Serialize;
 
 pub struct Serializer<W> {
@@ -208,7 +208,7 @@ where
             self.writer.bin_write_nat0(len as u64)?;
             Ok(self) // pass self as the handler for writing the elements
         } else {
-            Err(Error::custom("Size not provided"))
+            Err(Error::SeqSizeNotProvided)
         }
     }
 

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,5 +1,5 @@
 use difference::Changeset;
-use serde_bin_prot::{from_reader, to_writer};
+use serde_bin_prot::{to_writer};
 use std::fmt::Write;
 
 mod common;

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,5 +1,5 @@
 use difference::Changeset;
-use serde_bin_prot::{to_writer};
+use serde_bin_prot::to_writer;
 use std::fmt::Write;
 
 mod common;

--- a/tests/floats.rs
+++ b/tests/floats.rs
@@ -1,5 +1,5 @@
 use difference::Changeset;
-use serde_bin_prot::{to_writer};
+use serde_bin_prot::to_writer;
 use std::f64;
 use std::fmt::Write;
 

--- a/tests/floats.rs
+++ b/tests/floats.rs
@@ -1,5 +1,5 @@
 use difference::Changeset;
-use serde_bin_prot::{from_reader, to_writer};
+use serde_bin_prot::{to_writer};
 use std::f64;
 use std::fmt::Write;
 


### PR DESCRIPTION
## Rewrite the error module

- Removes the unused variants that were borrowed from the protobuf impl
- Refactor errors using `thiserror` macros
- Ensure no error string are in code outside error module

## Issues

Closes #7 