### PR TITLE
Adds deserializing of enums

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -29,7 +29,9 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        // can only deserialize any for a self describing protocol 
+        // which bin_io is not
+        Err(Error::WontImplement)
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value>
@@ -137,14 +139,14 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::WontImplement)
     }
 
     fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
-        unimplemented!()
+        Err(Error::WontImplement)
     }
 
     // An absent optional is represented as 0x00
@@ -258,7 +260,8 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        todo!()
+        // identifiers are not used as it is a binary protocol
+        Err(Error::WontImplement)
     }
 
     // Like `deserialize_any` but indicates to the `Deserializer` that it makes
@@ -366,7 +369,6 @@ impl<'de, 'a, R: Read> de::VariantAccess<'de> for Enum<'a, R> {
         Ok(())
     }
 
-    // TODO: Still what is this??
     fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
     where
         T: de::DeserializeSeed<'de>,
@@ -385,6 +387,6 @@ impl<'de, 'a, R: Read> de::VariantAccess<'de> for Enum<'a, R> {
     where
         V: Visitor<'de>,
     {
-        de::Deserializer::deserialize_tuple(self.de, fields.len(), visitor)
+        de::Deserializer::deserialize_struct(self.de, "", fields, visitor)
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -359,7 +359,7 @@ impl<'de, 'a, R: Read> EnumAccess<'de> for Enum<'a, R> {
     {
         let index = self.de.rdr.bin_read_variant_index()?;
         let de: U32Deserializer<Self::Error> = (index as u32).into_deserializer();
-        let v = DeserializeSeed::deserialize(seed, de)?; // let val = seed.deserialize(&mut *self.de)?;
+        let v = DeserializeSeed::deserialize(seed, de)?;
         Ok((v, self))
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,10 @@ pub enum Error {
         pos: usize,
     },
 
+    /// Functionality will not be implemented. Probably it does not make sense for this format
+    #[error("Functionality will not be implemented. Probably it does not make sense for this format")]    
+    WontImplement,
+
     /// Some user-defined error occurred.
     #[error("{message}")]
     Custom {

--- a/src/error.rs
+++ b/src/error.rs
@@ -55,7 +55,9 @@ pub enum Error {
     },
 
     /// Functionality will not be implemented. Probably it does not make sense for this format
-    #[error("Functionality will not be implemented. Probably it does not make sense for this format")]    
+    #[error(
+        "Functionality will not be implemented. Probably it does not make sense for this format"
+    )]
     WontImplement,
 
     /// Some user-defined error occurred.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod consts;
 mod de;
-mod error;
+pub mod error;
 pub mod integers;
 mod read_ext;
 mod ser;

--- a/src/read_ext.rs
+++ b/src/read_ext.rs
@@ -112,7 +112,7 @@ pub trait ReadBinProtExt: io::Read {
     }
 
     fn bin_read_variant_index(&mut self) -> Result<u8> {
-        self.read_u8().map_err(|e| Error::Io(e))
+        self.read_u8().map_err(Error::Io)
     }
 
     fn bin_read_string(&mut self) -> Result<String> {

--- a/src/read_ext.rs
+++ b/src/read_ext.rs
@@ -110,6 +110,11 @@ pub trait ReadBinProtExt: io::Read {
         }
         .ok_or(Error::DestinationIntegerOverflow)
     }
+
+    fn bin_read_variant_index(&mut self) -> Result<u8> {
+        self.read_u8().map_err(|e| Error::Io(e))
+    }
+
 }
 
 /// All types that implement `Read` get methods defined in `ReadBinProtIntegerExt`

--- a/src/write_ext.rs
+++ b/src/write_ext.rs
@@ -102,6 +102,21 @@ pub trait WriteBinProtExt: io::Write {
     fn bin_write_float64(&mut self, f: &f64) -> Result<usize, io::Error> {
         self.write(&f.to_le_bytes()).map(|_| 8)
     }
+
+
+    // for enums/variants with n variants the variant index
+    // is written out as follows:
+    // n <= 256    ->  write out lower 8 bits of n  (1 byte)
+    // n <= 65536  ->  write out lower 16 bits of n (2 bytes)
+    fn bin_write_variant_index(&mut self, i: u32) -> Result<usize, io::Error> {
+        // WARNING: This does not implement the requirement above
+        // It is tricky to determine how many variants an enum has
+        // and therfore which of the above cases to use
+        // This assumes all enums have < 256 variants
+        // This probably catches 99% of cases but is not strictly
+        // in compliance with the protocol
+        self.write_u8(i as u8).map(|_| 1) // truncating downcast
+    }
 }
 
 /// All types that implement `Write` get methods defined in `WriteBinProtIntegerExt`

--- a/src/write_ext.rs
+++ b/src/write_ext.rs
@@ -103,7 +103,6 @@ pub trait WriteBinProtExt: io::Write {
         self.write(&f.to_le_bytes()).map(|_| 8)
     }
 
-
     // for enums/variants with n variants the variant index
     // is written out as follows:
     // n <= 256    ->  write out lower 8 bits of n  (1 byte)

--- a/tests/compound_types.rs
+++ b/tests/compound_types.rs
@@ -21,6 +21,38 @@ struct TestFieldAttrs {
     i: i16,
 }
 
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct CompressedPoly {
+    version: u8,
+    x: [u8; 32],
+    is_odd: bool
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub enum E {
+    A, B, C
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
+pub struct PublicKey{
+    version: u8,
+    poly: CompressedPoly
+}
+
+
+impl PublicKey {
+    pub fn new() -> Self{
+        PublicKey {
+            version: 1,
+            poly: CompressedPoly {
+                version: 1,
+                x: [0x0; 32],
+                is_odd: false
+            }
+        }
+    }
+}
+
 #[test]
 fn roundtrip_tuple_struct() {
     common::roundtrip_test(TestTupleStruct(
@@ -37,6 +69,16 @@ fn roundtrip_tuple_struct() {
 }
 
 #[test]
+fn roundtrip_array_in_struct() {
+    common::roundtrip_test( PublicKey::new() )
+}
+
+#[test]
 fn roundtrip_nested_structs() {
     common::roundtrip_test(B { a: A(false) });
+}
+
+#[test]
+fn roundtrip_enum() {
+    common::roundtrip_test(E::A);
 }

--- a/tests/compound_types.rs
+++ b/tests/compound_types.rs
@@ -25,30 +25,31 @@ struct TestFieldAttrs {
 pub struct CompressedPoly {
     version: u8,
     x: [u8; 32],
-    is_odd: bool
+    is_odd: bool,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub enum E {
-    A, B, C
+    A,
+    B,
+    C,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
-pub struct PublicKey{
+pub struct PublicKey {
     version: u8,
-    poly: CompressedPoly
+    poly: CompressedPoly,
 }
 
-
 impl PublicKey {
-    pub fn new() -> Self{
+    pub fn new() -> Self {
         PublicKey {
             version: 1,
             poly: CompressedPoly {
                 version: 1,
                 x: [0x0; 32],
-                is_odd: false
-            }
+                is_odd: false,
+            },
         }
     }
 }
@@ -70,7 +71,7 @@ fn roundtrip_tuple_struct() {
 
 #[test]
 fn roundtrip_array_in_struct() {
-    common::roundtrip_test( PublicKey::new() )
+    common::roundtrip_test(PublicKey::new())
 }
 
 #[test]


### PR DESCRIPTION
# Adds deserializing enums

Prior to this trying to deserialize an enum resulted in a panic. The default implementation attempted to deserailize an idenitifier to identify the enum variant. This uses the variant_int that is written during serialization.

## Tests

Adds a test showing roundtrip of an enum