### PR TITLE
Fix issue with byte arrays

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -78,7 +78,7 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
-        visitor.visit_u8(self.rdr.bin_read_integer()?)
+        visitor.visit_u8(self.rdr.read_u8()?)
     }
 
     fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod consts;
 mod de;
-mod error;
+pub mod error;
 pub mod integers;
 mod read_ext;
 mod ser;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -92,7 +92,7 @@ where
     }
 
     fn serialize_u8(self, v: u8) -> Result<()> {
-        self.writer.bin_write_integer(v)?;
+        self.write_byte(v)?;
         Ok(())
     }
 

--- a/tests/compound_types.rs
+++ b/tests/compound_types.rs
@@ -47,7 +47,7 @@ impl PublicKey {
             version: 1,
             poly: CompressedPoly {
                 version: 1,
-                x: [0x0; 32],
+                x: [0xFF; 32],
                 is_odd: false,
             },
         }


### PR DESCRIPTION
Serde was attempting to deserialize u8s as integers which fails for byte that are larger than 0x08. This changes behavior to just serialize and deserialize u8s directly as bytes. 