### PR TITLE
Update integer test cases to also print jane streets test cases repr …

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,12 +1,14 @@
 use serde::{Deserialize, Serialize};
 use serde_bin_prot::{from_reader, to_writer};
 use std::fmt::Debug;
-use std::fmt::Write;
+use std::io::Write;
+use std::fs::File;
+use serde_bin_prot::WriteBinProtExt;
 
 /// Prints a byte array according to the style used in the Jane Street
 /// bin_prot tests. Byte array is reversed and padded up to max length with ..
 /// Bytes are written in hex with lowercase letters and no 0x prefix
-pub fn print_byte_array<W: Write>(w: &mut W, bytes: &[u8], max_len: usize) {
+pub fn write_byte_array<W: std::fmt::Write>(w: &mut W, bytes: &[u8], max_len: usize) {
     let padding = max_len - bytes.len();
     for _ in 0..padding {
         write!(w, ".. ").unwrap();
@@ -15,6 +17,25 @@ pub fn print_byte_array<W: Write>(w: &mut W, bytes: &[u8], max_len: usize) {
     for b in bytes.iter().rev() {
         write!(w, "{:02x} ", b).unwrap();
     }
+}
+
+/// Prints a byte array according to the style used in the Jane Street
+/// bin_prot tests. Byte array is reversed and padded up to max length with ..
+/// Bytes are written in hex with lowercase letters and no 0x prefix
+pub fn write_integer_test_repr(num: i64, max_len: usize, f: &mut File) {
+    let mut bytes:Vec<u8> = vec![];
+    bytes.bin_write_integer(num).unwrap();
+    
+    let padding = max_len - bytes.len();
+    for _ in 0..padding {
+        f.write(".. ".as_bytes()).unwrap();
+    }
+    for i in bytes.iter().rev() {
+        let fmt = format!("{:02x} ", i);
+        f.write(fmt.as_bytes()).unwrap();
+    }
+    
+    f.write(format!("-> {}\n", num).as_bytes()).unwrap();
 }
 
 pub fn roundtrip_test<'a, T: Serialize + Deserialize<'a> + PartialEq + Debug>(val: T) {


### PR DESCRIPTION
Changes:

1. Updates the print_byte_array function to also output jane-streets test repr files. Might be helpful in future to compare against any changes with jane street's test output.

This does not add full list of reprs, like the network_int32 as they seem redundant on Rust side. (This should be confirmed though if the regular Rust i32, i64 is sufficient for handling all other int types in ocaml bin-prot)

Close #24 