### PR TITLE
add bool and struct tests from bin_prot library

### DIFF
--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -4,7 +4,10 @@ mod common;
 use common::TestCase;
 
 fn bool_test_cases() -> Vec<TestCase<bool>> {
-    vec![TestCase::new(true, vec![1]), TestCase::new(false, vec![0])]
+    vec![
+        TestCase::new(true, vec![0x01]),
+        TestCase::new(false, vec![0x00]),
+    ]
 }
 
 #[test]

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -1,22 +1,7 @@
 use serde_bin_prot::to_writer;
-use std::fmt::Write;
 
 mod common;
-
-#[derive(Debug)]
-pub struct TestCase<T> {
-    input: T,
-    expected: Vec<u8>,
-}
-
-impl<T> TestCase<T> {
-    pub fn new(input: T, expected: Vec<u8>) -> Self {
-        TestCase {
-            input: input,
-            expected: expected,
-        }
-    }
-}
+use common::TestCase;
 
 fn bool_test_cases() -> Vec<TestCase<bool>> {
     vec![TestCase::new(true, vec![1]), TestCase::new(false, vec![0])]

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -1,4 +1,3 @@
-//use difference::Changeset;
 use serde_bin_prot::to_writer;
 use std::fmt::Write;
 
@@ -25,14 +24,9 @@ fn bool_test_cases() -> Vec<TestCase<bool>> {
 
 #[test]
 fn test_serialize_bools() {
-    let mut buf = String::new();
-    writeln!(&mut buf).unwrap();
-
     for val in bool_test_cases() {
-        //println!("case {:?}", val);
         let mut output = Vec::<u8>::new();
         to_writer(&mut output, &val.input).unwrap();
-        //println!("out {:?}", output);
         assert_eq!(val.expected, output);
     }
 }

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -1,0 +1,45 @@
+//use difference::Changeset;
+use serde_bin_prot::to_writer;
+use std::fmt::Write;
+
+mod common;
+
+#[derive(Debug)]
+pub struct TestCase<T> {
+    input: T,
+    expected: Vec<u8>,
+}
+
+impl<T> TestCase<T> {
+    pub fn new(input: T, expected: Vec<u8>) -> Self {
+        TestCase {
+            input: input,
+            expected: expected,
+        }
+    }
+}
+
+fn bool_test_cases() -> Vec<TestCase<bool>> {
+    vec![TestCase::new(true, vec![1]), TestCase::new(false, vec![0])]
+}
+
+#[test]
+fn test_serialize_bools() {
+    let mut buf = String::new();
+    writeln!(&mut buf).unwrap();
+
+    for val in bool_test_cases() {
+        //println!("case {:?}", val);
+        let mut output = Vec::<u8>::new();
+        to_writer(&mut output, &val.input).unwrap();
+        //println!("out {:?}", output);
+        assert_eq!(val.expected, output);
+    }
+}
+
+#[test]
+fn test_roundtrip_bools() {
+    for val in bool_test_cases() {
+        common::roundtrip_test(val.input);
+    }
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,6 +3,21 @@ use serde_bin_prot::{from_reader, to_writer};
 use std::fmt::Debug;
 use std::fmt::Write;
 
+#[derive(Debug)]
+pub struct TestCase<T> {
+    pub input: T,
+    pub expected: Vec<u8>,
+}
+
+impl<T> TestCase<T> {
+    pub fn new(input: T, expected: Vec<u8>) -> Self {
+        TestCase {
+            input: input,
+            expected: expected,
+        }
+    }
+}
+
 /// Prints a byte array according to the style used in the Jane Street
 /// bin_prot tests. Byte array is reversed and padded up to max length with ..
 /// Bytes are written in hex with lowercase letters and no 0x prefix

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -3,26 +3,12 @@ use serde_bin_prot::to_writer;
 use std::f64::INFINITY;
 
 mod common;
+use common::TestCase;
 
 #[derive(Debug)]
 enum StructTestCases {
     TestA(A),
     TestB(B),
-}
-
-#[derive(Debug)]
-struct TestCase {
-    input: StructTestCases,
-    expected: Vec<u8>,
-}
-
-impl TestCase {
-    fn new(input: StructTestCases, expected: Vec<u8>) -> Self {
-        TestCase {
-            input: input,
-            expected: expected,
-        }
-    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -43,7 +29,7 @@ struct b_inner {
     x: i64,
 }
 
-fn struct_test_cases() -> Vec<TestCase> {
+fn struct_test_cases() -> Vec<TestCase<StructTestCases>> {
     let a0 = A { x: 0, y: 0.0 };
 
     let a0_expected = vec![0, 0, 0, 0, 0, 0, 0, 0, 0];

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -1,0 +1,103 @@
+use serde::{Deserialize, Serialize};
+use serde_bin_prot::to_writer;
+use std::f64::INFINITY;
+
+mod common;
+
+#[derive(Debug)]
+enum TestCaseType {
+    TestA(A),
+    TestB(B),
+}
+
+#[derive(Debug)]
+struct TestCase {
+    input: TestCaseType,
+    expected: Vec<u8>,
+}
+
+impl TestCase {
+    pub fn new(input: TestCaseType, expected: Vec<u8>) -> Self {
+        TestCase {
+            input: input,
+            expected: expected,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct A {
+    x: i64,
+    y: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct b_inner {
+    w: i64,
+    x: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct B {
+    y: b_inner,
+    z: Option<i64>,
+}
+
+fn struct_test_cases() -> Vec<TestCase> {
+    let a0 = A { x: 0, y: 0.0 };
+
+    let a0_expected = vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+    let a1 = A {
+        x: 2147483647,
+        y: INFINITY,
+    };
+
+    let mut a1_expected = vec![
+        0x7f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7f, 0xff, 0xff, 0xff, 0xfd,
+    ];
+    a1_expected.reverse();
+
+    let b0 = B {
+        y: b_inner { w: 0, x: 0 },
+        z: None,
+    };
+
+    let b0_expected = vec![0, 0, 0];
+
+    let b1 = B {
+        y: b_inner {
+            w: 9223372036854775807,
+            x: 2147483647,
+        },
+        z: None,
+    };
+
+    let mut b1_expected = vec![
+        0x00, 0x7f, 0xff, 0xff, 0xff, 0xfd, 0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfc,
+    ];
+    b1_expected.reverse();
+
+    vec![
+        TestCase::new(TestCaseType::TestA(a0), a0_expected),
+        TestCase::new(TestCaseType::TestA(a1), a1_expected),
+        TestCase::new(TestCaseType::TestB(b0), b0_expected),
+        TestCase::new(TestCaseType::TestB(b1), b1_expected),
+    ]
+}
+
+#[test]
+fn test_serialize_structs() {
+    for val in struct_test_cases() {
+        fn encode_and_compare<T: Serialize>(input: T, expected: Vec<u8>) {
+            let mut output = Vec::<u8>::new();
+            to_writer(&mut output, &input).unwrap();
+            assert_eq!(expected, output);
+        }
+
+        match val.input {
+            TestCaseType::TestA(input) => encode_and_compare(input, val.expected),
+            TestCaseType::TestB(input) => encode_and_compare(input, val.expected),
+        };
+    }
+}

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -5,19 +5,19 @@ use std::f64::INFINITY;
 mod common;
 
 #[derive(Debug)]
-enum TestCaseType {
+enum StructTestCases {
     TestA(A),
     TestB(B),
 }
 
 #[derive(Debug)]
 struct TestCase {
-    input: TestCaseType,
+    input: StructTestCases,
     expected: Vec<u8>,
 }
 
 impl TestCase {
-    pub fn new(input: TestCaseType, expected: Vec<u8>) -> Self {
+    fn new(input: StructTestCases, expected: Vec<u8>) -> Self {
         TestCase {
             input: input,
             expected: expected,
@@ -32,15 +32,15 @@ struct A {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct b_inner {
-    w: i64,
-    x: i64,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 struct B {
     y: b_inner,
     z: Option<i64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct b_inner {
+    w: i64,
+    x: i64,
 }
 
 fn struct_test_cases() -> Vec<TestCase> {
@@ -79,10 +79,10 @@ fn struct_test_cases() -> Vec<TestCase> {
     b1_expected.reverse();
 
     vec![
-        TestCase::new(TestCaseType::TestA(a0), a0_expected),
-        TestCase::new(TestCaseType::TestA(a1), a1_expected),
-        TestCase::new(TestCaseType::TestB(b0), b0_expected),
-        TestCase::new(TestCaseType::TestB(b1), b1_expected),
+        TestCase::new(StructTestCases::TestA(a0), a0_expected),
+        TestCase::new(StructTestCases::TestA(a1), a1_expected),
+        TestCase::new(StructTestCases::TestB(b0), b0_expected),
+        TestCase::new(StructTestCases::TestB(b1), b1_expected),
     ]
 }
 
@@ -96,8 +96,8 @@ fn test_serialize_structs() {
         }
 
         match val.input {
-            TestCaseType::TestA(input) => encode_and_compare(input, val.expected),
-            TestCaseType::TestB(input) => encode_and_compare(input, val.expected),
+            StructTestCases::TestA(input) => encode_and_compare(input, val.expected),
+            StructTestCases::TestB(input) => encode_and_compare(input, val.expected),
         };
     }
 }

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -25,19 +25,19 @@ impl TestCase {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct A {
     x: i64,
     y: f64,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct B {
     y: b_inner,
     z: Option<i64>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct b_inner {
     w: i64,
     x: i64,
@@ -98,6 +98,16 @@ fn test_serialize_structs() {
         match val.input {
             StructTestCases::TestA(input) => encode_and_compare(input, val.expected),
             StructTestCases::TestB(input) => encode_and_compare(input, val.expected),
+        };
+    }
+}
+
+#[test]
+fn test_roundtrip_structs() {
+    for val in struct_test_cases() {
+        match val.input {
+            StructTestCases::TestA(input) => common::roundtrip_test(input),
+            StructTestCases::TestB(input) => common::roundtrip_test(input),
         };
     }
 }

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -32,7 +32,7 @@ struct BInner {
 fn struct_test_cases() -> Vec<TestCase<StructTestCases>> {
     let a0 = A { x: 0, y: 0.0 };
 
-    let a0_expected = vec![0, 0, 0, 0, 0, 0, 0, 0, 0];
+    let a0_expected = vec![0x00; 9];
 
     let a1 = A {
         x: 2147483647,

--- a/tests/struct.rs
+++ b/tests/struct.rs
@@ -19,12 +19,12 @@ struct A {
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 struct B {
-    y: b_inner,
+    y: BInner,
     z: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-struct b_inner {
+struct BInner {
     w: i64,
     x: i64,
 }
@@ -45,14 +45,14 @@ fn struct_test_cases() -> Vec<TestCase<StructTestCases>> {
     a1_expected.reverse();
 
     let b0 = B {
-        y: b_inner { w: 0, x: 0 },
+        y: BInner { w: 0, x: 0 },
         z: None,
     };
 
     let b0_expected = vec![0, 0, 0];
 
     let b1 = B {
-        y: b_inner {
+        y: BInner {
             w: 9223372036854775807,
             x: 2147483647,
         },


### PR DESCRIPTION
- implement `bool` tests
- implement `struct` tests, correspond to `record1` and `record2` here: https://github.com/janestreet/bin_prot/blob/master/test/non_integers_repr.ml#L732

