### PR TITLE
Fix array serialization

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -205,6 +205,7 @@ impl<'de, 'a, R: Read> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: Visitor<'de>,
     {
+        let len = self.rdr.bin_read_nat0()?;
         visitor.visit_seq(SeqAccess::new(self, len))
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -202,8 +202,10 @@ where
     // specified in the type definition.
     // Polymorphic record fields are supported unless a value of the type bound
     // by the field were accessed, which would lead to an exception.
-    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
-        Ok(self)
+    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple> {
+        // write the output length first
+        self.writer.bin_write_nat0(len as u64)?;
+        Ok(self) // pass self as the handler for writing the elements
     }
 
     // Tuple structs look just like sequences in JSON.

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,51 +1,18 @@
-use difference::Changeset;
-use serde_bin_prot::to_writer;
-use std::fmt::Write;
 
 mod common;
-use common::print_byte_array;
-
-const MAX_BYTES: usize = 11;
-
-const EXPECTED: &str = r#"
-.. .. .. .. .. .. .. .. .. .. 00 -> []
-.. .. .. .. .. .. .. .. .. 00 01 -> [0]
-.. .. .. .. .. .. .. .. 01 00 02 -> [0, 1]
-.. .. .. .. .. .. .. ff ff 01 02 -> [1, -1]
-.. .. .. .. 7f ff ff ff fd 00 02 -> [0, 2147483647]
-80 00 00 00 fd 7f ff ff ff fd 02 -> [2147483647, -2147483648]
-"#;
-
-fn test_cases() -> Vec<Vec<i32>> {
-    vec![
-        vec![],
-        vec![0],
-        vec![0, 1],
-        vec![1, -1],
-        vec![0, i32::MAX],
-        vec![i32::MAX, i32::MIN],
-    ]
-}
-
-#[test]
-fn test_serialize_arrays() {
-    let mut buf = String::new();
-    writeln!(&mut buf).unwrap();
-    for val in test_cases() {
-        let mut output = Vec::<u8>::new();
-        to_writer(&mut output, &val).unwrap();
-        print_byte_array(&mut buf, &output, MAX_BYTES);
-        writeln!(&mut buf, "-> {:?}", val).expect("its cooked");
-    }
-
-    let cs = Changeset::new(&buf, EXPECTED, "");
-    println!("{}", cs);
-    assert_eq!(cs.distance, 0)
-}
 
 #[test]
 fn test_roundtrip_arrays() {
-    for val in test_cases() {
-        common::roundtrip_test(val);
-    }
+    let test_case:[i32;0] = [];
+    common::roundtrip_test(test_case);
+    let test_case = [0i32];
+    common::roundtrip_test(test_case);
+    let test_case = [0i32, 1];
+    common::roundtrip_test(test_case);
+    let test_case = [1i32, -1];
+    common::roundtrip_test(test_case);
+    let test_case = [0i32, 2147483647];
+    common::roundtrip_test(test_case);
+    let test_case = [2147483647i32, -2147483648];
+    common::roundtrip_test(test_case);
 }


### PR DESCRIPTION

Modifies `serialize_tuple` call to additionally write the number of bytes in Nat0 as prefix.
Note: The tests will be replaced with macro based test post this PR merge.

Closes #31 