### PR TITLE
UPDATE fix #29

### DIFF
--- a/src/read_ext.rs
+++ b/src/read_ext.rs
@@ -35,18 +35,7 @@ pub trait ReadBinProtExt: io::Read {
     // failing this will continue until the max number of bytes for a char
     // is encountered
     fn bin_read_char(&mut self) -> Result<char> {
-        let mut buf = [0; 4];
-        for i in 0..4 {
-            buf[i] = self.read_u8()?;
-            if let Ok(s) = core::str::from_utf8(&buf[..=i]) {
-                // can unwrap here as if from_utf8 returned Ok
-                // then there is at least one char in the string
-                return Ok(s.chars().next().unwrap());
-            }
-        }
-        Err(Error::InvalidUtf8 {
-            bytes: buf.to_vec(),
-        })
+        Ok(self.read_u8()? as char)
     }
 
     fn bin_read_integer<T: FromPrimitive>(&mut self) -> Result<T> {

--- a/src/read_ext.rs
+++ b/src/read_ext.rs
@@ -30,10 +30,7 @@ pub trait ReadBinProtExt: io::Read {
         }
     }
 
-    // This function individual bytes from the reader and appends them to a buffer
-    // With each new byte it attempts to convert the buffer to a utf-8 char and
-    // failing this will continue until the max number of bytes for a char
-    // is encountered
+    // This function reads a single byte as char
     fn bin_read_char(&mut self) -> Result<char> {
         Ok(self.read_u8()? as char)
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -128,7 +128,10 @@ where
 
     // Chars are ascii encoded and should be 1 byte
     fn serialize_char(self, v: char) -> Result<()> {
-        self.writer.bin_write_char(v).map_err(Into::into)
+        self.writer
+            .bin_write_char(v)
+            .map(|_| ())
+            .map_err(Into::into)
     }
 
     // First the length of the string is written as a Nat0 (in characters?)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -126,10 +126,9 @@ where
         Ok(())
     }
 
-    // Chars are UTF-8 encoded and may be between 1 and 4 bytes
+    // Chars are ascii encoded and should be 1 byte
     fn serialize_char(self, v: char) -> Result<()> {
-        self.writer.bin_write_char(v)?;
-        Ok(())
+        self.writer.bin_write_char(v).map_err(Into::into)
     }
 
     // First the length of the string is written as a Nat0 (in characters?)

--- a/src/write_ext.rs
+++ b/src/write_ext.rs
@@ -16,15 +16,10 @@ pub trait WriteBinProtExt: io::Write {
         self.write_u8(if b { 0x01 } else { 0x00 })
     }
 
-    // chars are utf-8 so can be 1-4 bytes long
+    // chars are 1 byte long
     fn bin_write_char(&mut self, c: char) -> Result<usize, io::Error> {
-        let mut buffer = [0_u8; 4]; // can fit any char
-        let len = c.len_utf8();
-        c.encode_utf8(&mut buffer);
-        for c in buffer.iter().take(len) {
-            self.write_u8(*c)?;
-        }
-        Ok(len)
+        self.write_u8(c as u8)?;
+        Ok(1)
     }
 
     fn bin_write_integer<T: Into<i64>>(&mut self, n: T) -> Result<usize, io::Error> {

--- a/src/write_ext.rs
+++ b/src/write_ext.rs
@@ -17,9 +17,8 @@ pub trait WriteBinProtExt: io::Write {
     }
 
     // chars are 1 byte long
-    fn bin_write_char(&mut self, c: char) -> Result<usize, io::Error> {
-        self.write_u8(c as u8)?;
-        Ok(1)
+    fn bin_write_char(&mut self, c: char) -> Result<(), io::Error> {
+        self.write_u8(c as u8)
     }
 
     fn bin_write_integer<T: Into<i64>>(&mut self, n: T) -> Result<usize, io::Error> {

--- a/src/write_ext.rs
+++ b/src/write_ext.rs
@@ -17,8 +17,9 @@ pub trait WriteBinProtExt: io::Write {
     }
 
     // chars are 1 byte long
-    fn bin_write_char(&mut self, c: char) -> Result<(), io::Error> {
-        self.write_u8(c as u8)
+    fn bin_write_char(&mut self, c: char) -> Result<usize, io::Error> {
+        self.write_u8(c as u8)?;
+        Ok(1)
     }
 
     fn bin_write_integer<T: Into<i64>>(&mut self, n: T) -> Result<usize, io::Error> {

--- a/tests/non_integers_repr.rs
+++ b/tests/non_integers_repr.rs
@@ -26,8 +26,8 @@ fn test_char() {
         0x00 -> '\u{000}',
         0x41 -> 'A',
         0x7a -> 'z',
-        0x3b -> ';'
-        // 0xff -> '\u{255}' // FIXME: https://github.com/ChainSafe/serde-bin-prot/issues/29
+        0x3b -> ';',
+        0xff -> 255u8 as char
     }
 }
 


### PR DESCRIPTION
bin-prot char are not utf-8 so just 1 byte long as C char, but I still need to check ocaml specs, the original test does not contain any utf-8 specific test case and looks like it's testing the lower and upper bounds 0 and 255.