### PR TITLE
ADD closes #30

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -27,11 +27,36 @@ pub(crate) struct B {
     pub(crate) y: BInner,
     pub(crate) z: Option<i64>,
 }
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub(crate) struct B2 {
+    pub(crate) y: BInner3,
+    pub(crate) z: Option<i64>,
+}
 
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub(crate) struct B3 {
+    pub(crate) y: BInner2,
+    pub(crate) z: Option<i64>,
+}
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub(crate) struct BInner {
     pub(crate) w: i64,
     pub(crate) x: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub(crate) enum BInner2 {
+    V0(BInner),
+    V1(BInner4),
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub(crate) struct BInner3 {
+    pub(crate) dummy: i64,
+    pub(crate) inner: BInner2,
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub(crate) enum BInner4 {
+    V0(BInner),
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -41,7 +66,15 @@ pub(crate) struct C {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub(crate) struct CInner(pub ());
+pub(crate) enum CInner2 {
+    V0,
+    V1(()),
+}
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub(crate) enum CInner {
+    V0,
+    V1(CInner2),
+}
 
 pub(crate) struct Outer {
     pub(crate) y: Inner,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -41,7 +41,7 @@ pub(crate) struct C {
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub(crate) struct CInner {}
+pub(crate) struct CInner(pub ());
 
 pub(crate) struct Outer {
     pub(crate) y: Inner,

--- a/tests/non_integers_repr.rs
+++ b/tests/non_integers_repr.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use crate::common::{BInner, Inner, Outer, A, B};
+use crate::common::{BInner, CInner, A, B, C};
 
 // Non-integer bin_prot size tests
 // Ported from: https://github.com/janestreet/bin_prot/blob/master/test/non_integers_repr.ml
@@ -150,6 +150,10 @@ fn test_inline_record() {
         },
         0x00 0x7f 0xff 0xff 0xff 0xfd 0x7f 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xfc -> B {
             y: BInner { w: 9223372036854775807, x: 2147483647 },
+            z: None,
+        },
+        0x00 0x00 -> C {
+            y: CInner(()),
             z: None,
         }
     }

--- a/tests/non_integers_repr.rs
+++ b/tests/non_integers_repr.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use crate::common::{BInner, CInner, A, B, C};
+use crate::common::{BInner, BInner2, BInner3, BInner4, CInner, CInner2, A, B, B2, B3, C};
 
 // Non-integer bin_prot size tests
 // Ported from: https://github.com/janestreet/bin_prot/blob/master/test/non_integers_repr.ml
@@ -144,16 +144,16 @@ fn test_record2() {
 #[test]
 fn test_inline_record() {
     bin_prot_test! {
-        .. .. .. .. .. .. .. .. .. .. .. .. 0x00 0x00 0x00 -> B {
-            y: BInner { w: 0, x: 0 },
+        .. .. .. .. .. .. .. .. .. .. .. .. 0x00 0x00 0x00 0x00 0x01-> B3 {
+            y: BInner2::V1(BInner4::V0(BInner { w: 0, x: 0 })),
             z: None,
         },
-        0x00 0x7f 0xff 0xff 0xff 0xfd 0x7f 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xfc -> B {
-            y: BInner { w: 9223372036854775807, x: 2147483647 },
+        0x00 0x7f 0xff 0xff 0xff 0xfd 0x7f 0xff 0xff 0xff 0xff 0xff 0xff 0xff 0xfc 0x00 0x01 -> B2 {
+            y: BInner3 { dummy: 1 , inner: BInner2::V0(BInner { w: 9223372036854775807, x: 2147483647 })},
             z: None,
         },
-        0x00 0x00 -> C {
-            y: CInner(()),
+        0x00 0x00 0x01 0x01 -> C {
+            y: CInner::V1(CInner2::V1(())),
             z: None,
         }
     }


### PR DESCRIPTION
The dummy CInner(pub ()) is able to be serialized as 0x00 0x00 since there is no inline record in rust I have to strip last 2 bytes for now