### PR TITLE
Value indexing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod error;
 pub mod integers;
 mod read_ext;
 mod ser;
-mod value;
+pub mod value;
 mod write_ext;
 
 pub use array::OcamlArray;

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,0 +1,66 @@
+use super::Value;
+use std::ops;
+
+/// A type that can be used to index into a `bin_prot::Value`.
+pub trait Index {
+    /// Return None if the key is not already in the array or object.
+    fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value>;
+}
+
+// Numeric indexing, only compatible with List and Tuple (or sum types containing either of these)
+impl Index for usize {
+    fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
+        match *v {
+            Value::List(ref vec) | Value::Tuple(ref vec) => vec.get(*self),
+            Value::Sum { ref value, .. } => match **value {
+                Value::List(ref vec) | Value::Tuple(ref vec) => vec.get(*self),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+// String indexing. Only compatible with Record (or sum types containg a record)
+impl Index for str {
+    fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
+        match *v {
+            Value::Record(ref map) => map.get(self),
+            Value::Sum { ref value, .. } => match **value {
+                Value::Record(ref map) => map.get(self),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+impl Index for String {
+    fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
+        self[..].index_into(v)
+    }
+}
+
+impl<'a, T> Index for &'a T
+where
+    T: ?Sized + Index,
+{
+    fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
+        (**self).index_into(v)
+    }
+}
+
+impl<I> ops::Index<I> for Value
+where
+    I: Index + std::fmt::Display,
+{
+    type Output = Value;
+
+    // The ops::Index will panic when indexing a value that doesn't exist
+    // This is consistent to the behaviour when indexing into an array
+    fn index(&self, index: I) -> &Value {
+        index
+            .index_into(self)
+            .unwrap_or_else(|| panic!("No value for index: {}", index))
+    }
+}

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -107,10 +107,14 @@ mod tests {
 
     #[test]
     fn index_into_tuple_variants() {
-        let val = Value::Sum{
+        let val = Value::Sum {
             name: "variant A".to_string(),
             index: 0,
-            value: Box::new(Value::List(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
+            value: Box::new(Value::List(vec![
+                Value::Int(1),
+                Value::Int(2),
+                Value::Int(3),
+            ])),
         };
         assert_eq!(val[0], Value::Int(1));
         assert_eq!(val[1], Value::Int(2));
@@ -123,7 +127,7 @@ mod tests {
         inner.insert("one".to_string(), Value::Int(1));
         inner.insert("two".to_string(), Value::Int(2));
 
-        let val = Value::Sum{
+        let val = Value::Sum {
             name: "variant A".to_string(),
             index: 0,
             value: Box::new(Value::Record(inner)),
@@ -156,5 +160,4 @@ mod tests {
         let val = Value::Int(1);
         assert!(val.inner().is_none());
     }
-
 }

--- a/src/value/visitor.rs
+++ b/src/value/visitor.rs
@@ -10,6 +10,7 @@ use serde::de::MapAccess;
 use serde::de::Visitor;
 use serde::de::{SeqAccess, VariantAccess};
 use serde::Deserialize;
+use std::collections::HashMap;
 
 pub struct ValueVisitor;
 
@@ -90,9 +91,9 @@ impl<'de> Visitor<'de> for ValueVisitor {
     where
         V: MapAccess<'de>,
     {
-        let mut values = Vec::new();
+        let mut values = HashMap::new();
         while let Some((k, v)) = visitor.next_entry()? {
-            values.push((k, v))
+            values.insert(k, v).unwrap(); // returns old value of replacing a key. This cannot happen here so can unwrap
         }
         Ok(Value::Record(values))
     }


### PR DESCRIPTION
## Overview

Adds indexing capabilities to `bin_prot::Value` similar to serde_json

- Can index List and Tuple variants using usize ( e.g.  value[0] )
- Can index records using strings (e.g. value['block_signature'] )
- Also tuple and struct Sum type variants can be accessed the same way
- Adds `inner` method on `Value` to allow access to the Rust option type contained in an Option variant of Value

Combined these should make it much much easier to write tests and other things that use the loosely typed bin_prot API
